### PR TITLE
fix: streaming render safety and async correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,25 +175,7 @@ Ex: `{% suspense obj obj2 %}`
 </ul>
 ```
 
-Important: If your async context variable is used by more than one suspense block, or you did not specify any variables on the tags, make sure to wrap your coroutines in tasks so they can be awaited multiple times.
-
-Ex: `asyncio.create_task(obj())`
-
-```python
-import asyncio
-
-from suspense.shortcuts import async_render
-
-
-# app/views.py
-async def view(request):
-    async def obj():
-        await asyncio.sleep(1)
-        return range(10)
-
-    task_obj = asyncio.create_task(obj())
-    return async_render(request, 'template.html', {'obj': task_obj})
-```
+Note: awaitables are wrapped in `asyncio` tasks internally, so the same coroutine can safely be shared by multiple suspense blocks — each block will await the same task and receive the same result.
 
 
 ### ASGI notes
@@ -215,4 +197,4 @@ uvx pre-commit install         # enable git hooks (optional)
 ```
 
 ## License
-This project is licensed under the MIT License. See the LICENSE file for more information.
+This project is licensed under the MIT License. See the LICENCE file for more information.

--- a/suspense/futures.py
+++ b/suspense/futures.py
@@ -12,32 +12,36 @@ def create(nodelist, context):
     return key, task
 
 
-def create_async(nodelist, context, async_context_keys):
+def create_async(nodelist, context, async_context_keys, shared_futures=None):
     key = str(uuid.uuid4())
+    if shared_futures is None:
+        shared_futures = {}
+
+    def resolve_awaitables():
+        if async_context_keys:
+            items = [(k, context.get(k, None)) for k in async_context_keys]
+        else:
+            items = list(context.flatten().items())
+
+        awaitables = []
+        for k, v in items:
+            if inspect.isawaitable(v):
+                future = shared_futures.get(id(v))
+                if future is None:
+                    future = asyncio.ensure_future(v)
+                    shared_futures[id(v)] = future
+                awaitables.append((k, future))
+        return awaitables
 
     async def task():
-        coroutines = []
-        if async_context_keys:
-            for k in async_context_keys:
-                v = context.get(k, None)
-                if v and inspect.isawaitable(v):
-                    coroutines.append((k, v))
-        else:
-            flatten_context = context.flatten()
-            for k, v in flatten_context.items():
-                if inspect.isawaitable(v):
-                    coroutines.append((k, v))
-
         async def wait_for(to_await):
             k, v = to_await
             return k, await v
 
-        results = await asyncio.gather(*[wait_for(co) for co in coroutines])
-        new_context = {}
-        for k, v in results:
-            new_context[k] = v
-
-        context.push(new_context)
+        results = await asyncio.gather(
+            *[wait_for(pair) for pair in resolve_awaitables()]
+        )
+        context.push(dict(results))
         return key, await asyncio.to_thread(nodelist.render, context)
 
-    return key, task()
+    return key, task

--- a/suspense/streaming_render.py
+++ b/suspense/streaming_render.py
@@ -8,43 +8,58 @@ logger = logging.getLogger(__name__)
 
 
 def streaming_render(request, template_name, context=None, using=None):
-    context = context or {}
-    context["is_async"] = False
+    context = {**context} if context else {}
+    context["_suspense_is_async"] = False
     content, tasks = _render_base_template(context, request, template_name, using)
     yield content
     if tasks:
-        with futures.ThreadPoolExecutor() as executor:
-            tasks = [executor.submit(task) for task in tasks]
-            for task in futures.as_completed(tasks):
+        executor = futures.ThreadPoolExecutor()
+        try:
+            submitted = [executor.submit(task) for task in tasks]
+            for future in futures.as_completed(submitted):
                 try:
-                    uid, result = task.result()
+                    uid, result = future.result()
                     yield _render_replacer(result, request, uid, using)
                 except Exception:
                     logger.exception(
                         f'failed to render suspense template "{template_name}"'
                     )
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
 
 
 async def async_streaming_render(request, template_name, context=None, using=None):
-    context = context or {}
-    context["is_async"] = True
-    content, tasks = _render_base_template(context, request, template_name, using)
+    context = {**context} if context else {}
+    context["_suspense_is_async"] = True
+    content, tasks = await asyncio.to_thread(
+        _render_base_template, context, request, template_name, using
+    )
     yield content
     if tasks:
-        for task in asyncio.as_completed([asyncio.create_task(task) for task in tasks]):
-            try:
-                uid, result = await task
-                yield _render_replacer(result, request, uid, using)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.exception(
-                    f'failed to render suspense template "{template_name}"'
-                )
+        pending = [asyncio.ensure_future(task()) for task in tasks]
+        try:
+            for task in asyncio.as_completed(pending):
+                try:
+                    uid, result = await task
+                    yield await asyncio.to_thread(
+                        _render_replacer, result, request, uid, using
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        f'failed to render suspense template "{template_name}"'
+                    )
+        finally:
+            for task in pending:
+                task.cancel()
 
 
 def _render_replacer(result, request, uid, using):
-    escaped_string = result.replace('`', '\\`')
+    # escape JS template literal: \ ` ${
+    escaped_string = (
+        result.replace('\\', '\\\\').replace('`', '\\`').replace('${', '\\${')
+    )
     return loader.render_to_string(
         "suspense/replacer.html",
         {
@@ -59,9 +74,8 @@ def _render_replacer(result, request, uid, using):
 
 def _render_base_template(context, request, template_name, using):
     content = loader.render_to_string(template_name, context, request, using=using)
-    if hasattr(request, "_suspense"):
-        tasks = request._suspense
-        delattr(request, "_suspense")
-    else:
-        tasks = []
+    tasks = getattr(request, "_suspense", [])
+    for attr in ("_suspense", "_suspense_shared"):
+        if hasattr(request, attr):
+            delattr(request, attr)
     return content, tasks

--- a/suspense/templatetags/suspense.py
+++ b/suspense/templatetags/suspense.py
@@ -34,13 +34,23 @@ class SuspenseNode(template.Node):
         self.async_context_keys = async_context_keys
 
     def render(self, context):
-        if context["is_async"]:
+        request = context.get("request", None)
+        is_async = context.get("_suspense_is_async", None)
+        if request is None or is_async is None:
+            # not a streaming response: render inline
+            return self.nodelist.render(context)
+
+        if is_async:
+            if not hasattr(request, "_suspense_shared"):
+                request._suspense_shared = {}
             uid, task = create_async(
-                self.nodelist, copy(context), self.async_context_keys
+                self.nodelist,
+                copy(context),
+                self.async_context_keys,
+                request._suspense_shared,
             )
         else:
             uid, task = create(self.nodelist, copy(context))
-        request = context["request"]
         if not hasattr(request, "_suspense"):
             request._suspense = []
         request._suspense.append(task)
@@ -71,7 +81,8 @@ class FallbackNode(template.Node):
 
 @register.simple_tag(name="webkit_extra_invisible_bytes", takes_context=True)
 def webkit_extra_invisible_bytes(context, byte_count=200):
-    agent = context["request"].META.get('HTTP_USER_AGENT', '')
+    request = context.get("request", None)
+    agent = request.META.get('HTTP_USER_AGENT', '') if request else ''
     if byte_count > 0 and 'AppleWebKit' in agent:
         zero_width_spaces = byte_count * "\u200b"
         return mark_safe(f'<div style="width: 0; height: 0;">{zero_width_spaces}</div>')

--- a/tests/templates/test_suspense_shared.html
+++ b/tests/templates/test_suspense_shared.html
@@ -1,0 +1,9 @@
+{% load suspense %}
+{% suspense shared %}
+    {% fallback %}first-fallback{% endfallback %}
+    first-{{ shared }}
+{% endsuspense %}
+{% suspense shared %}
+    {% fallback %}second-fallback{% endfallback %}
+    second-{{ shared }}
+{% endsuspense %}

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -19,24 +19,6 @@ def test_create_future():
 
 
 @pytest.mark.asyncio
-async def test_create_async_future_without_context_keys():
-    t = Template("<div>{{ a }}</div>")
-    nodelist = t.nodelist
-    context = template.context.Context()
-
-    async def a():
-        return 'bar'
-
-    context.push({'a': asyncio.create_task(a())})
-
-    uid, task = create_async(nodelist, context, ['a'])
-    result = await task
-    assert isinstance(result, tuple)
-    assert result[0] == uid
-    assert result[1] == '<div>bar</div>'
-
-
-@pytest.mark.asyncio
 async def test_create_async_future_with_context_keys():
     t = Template("<div>{{ a }}</div>")
     nodelist = t.nodelist
@@ -47,8 +29,45 @@ async def test_create_async_future_with_context_keys():
 
     context.push({'a': asyncio.create_task(a())})
 
-    uid, task = create_async(nodelist, context, [])
-    result = await task
+    uid, task = create_async(nodelist, context, ['a'])
+    result = await task()
     assert isinstance(result, tuple)
     assert result[0] == uid
     assert result[1] == '<div>bar</div>'
+
+
+@pytest.mark.asyncio
+async def test_create_async_future_without_context_keys():
+    t = Template("<div>{{ a }}</div>")
+    nodelist = t.nodelist
+    context = template.context.Context()
+
+    async def a():
+        return 'bar'
+
+    context.push({'a': asyncio.create_task(a())})
+
+    uid, task = create_async(nodelist, context, [])
+    result = await task()
+    assert isinstance(result, tuple)
+    assert result[0] == uid
+    assert result[1] == '<div>bar</div>'
+
+
+@pytest.mark.asyncio
+async def test_create_async_shared_coroutine():
+    t = Template("<div>{{ a }}</div>")
+    context = template.context.Context()
+
+    async def a():
+        return 'bar'
+
+    context.push({'a': a()})
+    shared = {}
+
+    uid1, task1 = create_async(t.nodelist, context, ['a'], shared)
+    uid2, task2 = create_async(t.nodelist, context, ['a'], shared)
+    result1 = await task1()
+    result2 = await task2()
+    assert result1[1] == '<div>bar</div>'
+    assert result2[1] == '<div>bar</div>'

--- a/tests/test_streaming_render.py
+++ b/tests/test_streaming_render.py
@@ -3,7 +3,11 @@ import asyncio
 import pytest
 from django.http import HttpRequest
 
-from suspense.streaming_render import async_streaming_render, streaming_render
+from suspense.streaming_render import (
+    _render_replacer,
+    async_streaming_render,
+    streaming_render,
+)
 
 
 def test_streaming_render():
@@ -96,3 +100,28 @@ async def test_async_streaming_render_cancel(caplog):
         await streaming_content.__anext__()
 
     assert len(caplog.records) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_render_shared_coroutine():
+    async def shared_loader():
+        return 'bar'
+
+    streaming_content = async_streaming_render(
+        HttpRequest(), "test_suspense_shared.html", {"shared": shared_loader()}
+    )
+
+    first = await streaming_content.__anext__()
+    assert 'first-fallback' in first
+    assert 'second-fallback' in first
+
+    chunks = [await streaming_content.__anext__(), await streaming_content.__anext__()]
+    assert any('first-bar' in chunk for chunk in chunks)
+    assert any('second-bar' in chunk for chunk in chunks)
+    with pytest.raises(StopAsyncIteration):
+        await streaming_content.__anext__()
+
+
+def test_render_replacer_escapes_js_template_literal():
+    html = _render_replacer('a`b\\c${d}', HttpRequest(), 'uid123', None)
+    assert 'a\\`b\\\\c\\${d}' in html

--- a/tests/test_suspense.py
+++ b/tests/test_suspense.py
@@ -16,7 +16,7 @@ def test_suspense():
         {% endsuspense %}
     """
         )
-        .render(context={"request": request, "is_async": False})
+        .render(context={"request": request, "_suspense_is_async": False})
     )
 
     assert 'abcdefg' not in html
@@ -44,7 +44,7 @@ async def test_suspense_async():
         {% endsuspense %}
     """
         )
-        .render(context={"request": request, "is_async": True})
+        .render(context={"request": request, "_suspense_is_async": True})
     )
 
     assert 'abcdefg' not in html
@@ -52,10 +52,52 @@ async def test_suspense_async():
     assert isinstance(request._suspense, list)
     assert len(request._suspense) == 1
     task = request._suspense[0]
-    result = await task
+    result = await task()
     assert isinstance(result, tuple)
     assert isinstance(result[0], str)
     assert 'abcdefg' in result[1]
+
+
+def test_suspense_without_streaming_context():
+    request = HttpRequest()
+    html = (
+        template.engines['django']
+        .from_string(
+            """
+        {% load suspense %}
+
+        {% suspense %}
+            {% fallback %}
+                loading...
+            {% endfallback %}
+            abcdefg
+        {% endsuspense %}
+    """
+        )
+        .render(context={"request": request})
+    )
+
+    assert 'abcdefg' in html
+    assert 'loading...' not in html
+    assert not hasattr(request, "_suspense")
+
+
+def test_suspense_without_request():
+    html = (
+        template.engines['django']
+        .from_string(
+            """
+        {% load suspense %}
+
+        {% suspense %}
+            abcdefg
+        {% endsuspense %}
+    """
+        )
+        .render(context={"_suspense_is_async": False})
+    )
+
+    assert 'abcdefg' in html
 
 
 def test_fallback():
@@ -74,7 +116,7 @@ def test_fallback():
         {% endsuspense %}
     """
         )
-        .render(context={"request": request, "is_async": False})
+        .render(context={"request": request, "_suspense_is_async": False})
     )
 
     assert 'abcdefg' not in html
@@ -106,7 +148,7 @@ async def test_fallback_async():
         {% endsuspense %}
     """
         )
-        .render(context={"request": request, "is_async": True})
+        .render(context={"request": request, "_suspense_is_async": True})
     )
 
     assert 'abcdefg' not in html
@@ -115,7 +157,7 @@ async def test_fallback_async():
     assert isinstance(request._suspense, list)
     assert len(request._suspense) == 1
     task = request._suspense[0]
-    result = await task
+    result = await task()
     assert isinstance(result, tuple)
     assert isinstance(result[0], str)
     assert 'abcdefg' in result[1]
@@ -153,4 +195,20 @@ def test_webkit_extra_invisible_bytes_webkit():
         .render(context={"request": request})
     )
 
-    assert '<div style="width: 0;height:0">\u200b\u200b</div>' not in html
+    assert '<div style="width: 0; height: 0;">\u200b\u200b</div>' in html
+
+
+def test_webkit_extra_invisible_bytes_without_request():
+    html = (
+        template.engines['django']
+        .from_string(
+            """
+        {% load suspense %}
+
+        {% webkit_extra_invisible_bytes 2 %}
+    """
+        )
+        .render(context={})
+    )
+
+    assert 'div' not in html


### PR DESCRIPTION
Fixes several bugs in the streaming render pipeline found during review.

## JS injection through `${...}`

Rendered content is injected into a JS template literal in `replacer.html`, but only backticks were escaped. Django autoescaping does not touch `$`, `{` or `\`, so this executed as JavaScript:

```
${alert(document.cookie)}
```

A trailing `\` also broke the closing backtick. Now `\`, `` ` `` and `${` are escaped in that order.

## KeyError outside streaming

`{% suspense %}` in a template rendered through plain `render` or `render_to_string` (emails, tests, includes) crashed on `context["is_async"]`. It now renders its content inline when there is no streaming context.

## Blocked event loop

The base template and replacer fragments were rendered synchronously inside the async generator, so any ORM query in the base template stalled the ASGI event loop. Both now render via `asyncio.to_thread`.

## Task leak on client disconnect

Closing the response generator left asyncio tasks pending and made `ThreadPoolExecutor.shutdown` wait for running threads. Sync path now uses `shutdown(wait=False, cancel_futures=True)`, async path cancels pending tasks in `finally`.

## Shared coroutines

One bare coroutine used by several suspense blocks raised `cannot reuse already awaited coroutine`. Awaitables are now wrapped in futures shared per request, so `asyncio.create_task` is no longer required:

```python
async def view(request):
    return async_render(request, "page.html", {"obj": load_data()})
```

The README section recommending manual `create_task` wrapping is updated accordingly.

## Internals

- `create_async` returns an async function instead of a coroutine, so unconsumed responses no longer emit "coroutine was never awaited" warnings
- streaming render copies the caller's context dict instead of mutating it, the internal flag is renamed to `_suspense_is_async` to avoid collisions with user variables
- webkit tag test asserted `not in` with a string that never matched and always passed, now asserts the actual markup
- with/without context keys test names in `test_futures.py` were swapped
